### PR TITLE
LayoutコンポーネントのCSSを修正しました

### DIFF
--- a/src/components/layout/layout.module.css
+++ b/src/components/layout/layout.module.css
@@ -1,14 +1,17 @@
-.layout{
-    display: flex;
+.layout {
+  display: flex;
 }
 
-.title{
-    font-size: 36px;
-    font-weight: normal;
+.title {
+  font-size: 36px;
+  font-weight: normal;
 }
 
-.sectionLayout{
-    padding: 80px;
-    justify-content: center;
-    align-items: center;
+.sectionLayout {
+  max-width: 1000px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 80px;
+  justify-content: center;
+  align-items: center;
 }


### PR DESCRIPTION
> 変更箇所
layout.module.css

> 変更内容
* max-widthで最大幅を指定
* widthで画面いっぱい広がるように変更
* marginで画面中央寄せ

> 画像（青枠内にコンテンツが入る）
 変更前
<img width="772" alt="スクリーンショット 2025-01-17 16 32 47" src="https://github.com/user-attachments/assets/e1b96d12-6964-4e34-8382-71d1e36b8860" />

 変更後
<img width="853" alt="スクリーンショット 2025-01-17 16 32 18" src="https://github.com/user-attachments/assets/3debd604-520e-400e-981a-4d2d7a4c07ed" />

