### PR TITLE
ユーザーごとの投稿一覧ページ作成、db.jsonのID修正

### DIFF
--- a/db/data.json
+++ b/db/data.json
@@ -63,7 +63,7 @@
       "title": "JSONの基礎知識",
       "content": "この記事では、JSONについて詳しく解説します。\n\n### JSONとは？\nJSONはデータ交換フォーマットの一つで、軽量かつ人間にとって読みやすい形式です。\n\n### 使用例\nたとえば、次のような形式でデータを表現できます：\n```json\n{\n  \"name\": \"太郎\",\n  \"age\": 25\n}\n```\n\nこのフォーマットは多くのプログラミング言語でサポートされています。",
       "user": {
-        "userId": 1,
+        "userId": 101,
         "name": "山田 太郎",
         "email": "yamada.taro@example.com",
         "password": null,
@@ -93,7 +93,7 @@
       "title": "プログラミング初心者ガイド",
       "content": "プログラミングを始めるための基本ステップを紹介します。\n\n### はじめに\nプログラミングの第一歩は、適切な言語を選ぶことです。\n\n### 学習方法\n1. 書籍やオンライン教材を利用する。\n2. 実際にコードを書いてみる。\n\n### おすすめツール\n- VSCode\n- GitHub\n- Stack Overflow",
       "user": {
-        "userId": 2,
+        "userId": 102,
         "name": "佐藤 花子",
         "email": "sato.hanako@example.com",
         "password": null,
@@ -117,7 +117,7 @@
       "title": "Gitの基礎知識",
       "content": "Pythonを初めて学ぶ人のためのガイドです。\n\n### 特徴\nPythonはシンプルな構文で、多くの初心者に最適です。\n\n### インストール\n公式サイトからPythonをダウンロードしてインストールしましょう。\n\n### 基本文法\n以下は、Hello Worldを表示するコード例です：\n```python\nprint(\"Hello, World!\")\n```",
       "user": {
-        "userId": 3,
+        "userId": 103,
         "name": "高橋 一郎",
         "email": "takahashi.ichiro@example.com",
         "password": null,
@@ -147,7 +147,7 @@
       "title": "HTMLとCSSの基本",
       "content": "HTMLとCSSを学び、ウェブサイトを作成する基本を説明します。\n\n### HTMLとは？\nHTMLはウェブページの骨組みを作るための言語です。\n\n### CSSとは？\nCSSはウェブページの見た目を装飾するためのスタイルシート言語です。\n\n### 実例\n以下はシンプルなHTMLとCSSの例です：\n```html\n<!DOCTYPE html>\n<html>\n<head>\n  <style>\n    body { font-family: Arial; }\n  </style>\n</head>\n<body>\n  <h1>Hello, World!</h1>\n</body>\n</html>\n```",
       "user": {
-        "userId": 4,
+        "userId": 104,
         "name": "中村 京子",
         "email": "nakamura.kyoko@example.com",
         "password": null,
@@ -171,7 +171,7 @@
       "title": "JavaScript入門",
       "content": "バージョン管理システムGitの基本を学びましょう。\n\n### Gitとは？\nGitはコードの履歴を管理するための分散型バージョン管理システムです。\n\n### 基本コマンド\n- `git init` : リポジトリの初期化\n- `git add` : ファイルをステージング\n\n### チュートリアル\n以下のコマンドでリポジトリを作成してみましょう：\n```bash\ngit init my-project\ncd my-project\ngit add .\n```",
       "user": {
-        "userId": 5,
+        "userId": 105,
         "name": "鈴木 次郎",
         "email": "suzuki.jiro@example.com",
         "password": null,

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -52,7 +52,7 @@ export default function Header() {
             <li>
               {text && (
                 <p>
-                  <Link href="#" onClick={handleClick}>
+                  <Link href="/login" onClick={handleClick}>
                     ログイン
                   </Link>
                 </p>

--- a/src/components/header/header.module.css
+++ b/src/components/header/header.module.css
@@ -1,58 +1,50 @@
-.header{
-    background-color: var(--foreground);
-    font-size: 16px;
-
+.header {
+  background-color: var(--foreground);
+  font-size: 16px;
 }
 
-.headerIcons{
-    height: 70px;
-    border-bottom: 1px solid var(--background);
-    display: flex;
-    justify-content: end;
-    align-items: center;
-    padding-right: 1rem;
-
+.headerIcons {
+  height: 70px;
+  border-bottom: 1px solid var(--background);
+  display: flex;
+  justify-content: end;
+  align-items: center;
+  padding-right: 1rem;
 }
-.mobileUl{
-    display: flex;
-    flex-direction: column;
-    justify-self: start;
-    align-items:start;
-    gap: 1.5rem;
-    padding: 20px;
-
+.mobileUl {
+  display: flex;
+  flex-direction: column;
+  justify-self: start;
+  align-items: start;
+  gap: 1.5rem;
+  padding: 20px;
 }
 
-.pcUl{
-    display: none;
+.pcUl {
+  display: none;
 }
-
 
 @media screen and (min-width: 600px) {
+  .header {
+    height: 100vh;
+    width: 250px;
+    background-color: var(--foreground);
+    color: var(--background);
+  }
 
-    .header{
-        width: 250px;
-        height:200vh;
-        background-color: var(--foreground);
-        color:var(--background)
-    }
+  .headerIcons {
+    display: none;
+  }
 
-    .headerIcons{
-        display: none;
-    }
-    
-    .headerContents{
-        padding: 70px 35px;
-    }
-    
-    
-    .pcUl{
-        display: flex;
-        flex-direction: column;
-        gap: 30px;
-        list-style: none;
-        text-align: center;
-    
-    }
-  
+  .headerContents {
+    padding: 70px 35px;
+  }
+
+  .pcUl {
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+    list-style: none;
+    text-align: center;
+  }
 }

--- a/src/pages/register/index.tsx
+++ b/src/pages/register/index.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import inputStyle from "@/components/input/input.module.css";
 import Button from "@/components/button/Button";
 import registerStyle from "@/styles/Register.module.css";
-import ColorLink from "@/components/ColorLink/ColorLink";
+import ColorLink from "@/components/colorLink/ColorLink";
 import { useRouter } from "next/router";
 
 export default function Register() {

--- a/src/pages/user/[id].tsx
+++ b/src/pages/user/[id].tsx
@@ -44,10 +44,10 @@ export default function PostList({
   const usersName = filteredData[0].user.name;
   return (
     <Layout
-      headContent={`${usersName}の投稿一覧`}
-      headName={`${usersName}の投稿一覧`}
-      pageTitle={`${usersName}の投稿一覧`}
-      headTitle={`${usersName}の投稿一覧`}
+      headContent={`${usersName}さんの投稿一覧`}
+      headName={`${usersName}さんの投稿一覧`}
+      pageTitle={`${usersName}さんの投稿一覧`}
+      headTitle={`${usersName}さんの投稿一覧`}
     >
       <Lists pagedata={filteredData}></Lists>
     </Layout>

--- a/src/pages/user/[id].tsx
+++ b/src/pages/user/[id].tsx
@@ -1,0 +1,55 @@
+import Layout from "@/components/layout/Layout";
+import Lists from "@/components/lists/Lists";
+import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from "next";
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const res = await fetch("http://localhost:8000/articles");
+  const articles = await res.json();
+
+  const paths = articles.map((article: any) => ({
+    params: { id: article.user.userId.toString() },
+  }));
+  return { paths, fallback: false };
+};
+
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const res = await fetch(`http://localhost:8000/articles`);
+  const articles = await res.json();
+
+  return {
+    props: {
+      articles,
+      userId: params?.id || null, // 動的ルートのIDを渡す
+    },
+  };
+};
+
+interface Article {
+  id: number;
+  user: {
+    userId: string;
+  };
+  title: string;
+  content: string;
+}
+
+export default function PostList({
+  articles,
+  userId,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  const filteredData = articles.filter(
+    (articles: any) => articles.user.userId === Number(userId)
+  );
+
+  const usersName = filteredData[0].user.name;
+  return (
+    <Layout
+      headContent={`${usersName}の投稿一覧`}
+      headName={`${usersName}の投稿一覧`}
+      pageTitle={`${usersName}の投稿一覧`}
+      headTitle={`${usersName}の投稿一覧`}
+    >
+      <Lists pagedata={filteredData}></Lists>
+    </Layout>
+  );
+}


### PR DESCRIPTION
投稿一覧からユーザーの名前をクリックすると、
そのユーザーの投稿一覧に遷移するよう設定しました。

その他微修正していますmm
- db.jsonのIDを修正
- サイドバー内「ログイン」を押下するとログインページに遷移するように修正
- 新規登録ページのエラー微修正
![image](https://github.com/user-attachments/assets/196ee4dd-fe43-41d1-923d-23c31dd4d78d)




