### PR TITLE
クライアント側でログイン時にクッキーを設定

### DIFF
--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -77,7 +77,7 @@ export default function Login() {
         if (users.length > 0) {
           console.log("ログイン成功");
 
-          // クライアント側でクッキーを設定
+          // 仮としてクライアント側でクッキーを設定（認証系はサーバ側で設定した方がセキュリティ的に良い）
           document.cookie = `loginID=${users[0].id}; path=/; max-age=3600; secure; samesite=strict`;
         } else {
           setPassError("メールアドレス又はパスワードが誤っています");

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -76,6 +76,9 @@ export default function Login() {
 
         if (users.length > 0) {
           console.log("ログイン成功");
+
+          // クライアント側でクッキーを設定
+          document.cookie = `loginID=${users[0].id}; path=/; max-age=3600; secure; samesite=strict`;
         } else {
           setPassError("メールアドレス又はパスワードが誤っています");
           setInputEmailArea(inputStyle.errorInput);


### PR DESCRIPTION
> 変更箇所
* login/index.tsx

> 変更内容
ログインをしたらクッキーが発火されるようにコードを追加しました。
APIを作成していないため、クライアント側でクッキーを設定していますが、
本来認証系はサーバ側で設定した方がセキュリティ的にいいみたいです！
（これはバックエンド側からのAPIとくっつける時に再度修正..?）

> 画像
<img width="1429" alt="スクリーンショット 2025-01-28 14 29 47" src="https://github.com/user-attachments/assets/d78431d5-78fa-4d7e-a0e8-a1fd406200af" />
