### PR TITLE
投稿ページのデータの送受信

### DIFF
--- a/src/pages/new_post/index.tsx
+++ b/src/pages/new_post/index.tsx
@@ -2,8 +2,21 @@ import Layout from "@/components/layout/Layout";
 import MarkDown from "@/components/markDown/MarkDown";
 import { useState } from "react";
 import { useRouter } from "next/router";
+import { GetServerSideProps } from "next";
 
-export default function NewPost() {
+interface Props {
+  data: {
+    id: number;
+    name: string;
+    email: string;
+    password: string;
+    introduction: string;
+    created_at: string;
+    updated_at: string;
+  };
+}
+
+export default function NewPost({ data }: Props) {
   const router = useRouter();
 
   const [postTitle, setPostTitle] = useState("");
@@ -15,10 +28,12 @@ export default function NewPost() {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          // "X-AUTH-TOKEN": token,
         },
         body: JSON.stringify({
           title: postTitle,
           content: postTextarea,
+          user: data,
         }),
       });
       //ここでデータ(articleのidがほしい)取ってくる
@@ -50,3 +65,19 @@ export default function NewPost() {
     </Layout>
   );
 }
+
+export const getServerSideProps = (async ({ req }) => {
+  console.log("cookie", req.cookies);
+
+  const res = await fetch(`http://localhost:8000/users/${req.cookies.loginID}`);
+
+  const data = await res.json();
+  console.log(data);
+  // const token=req.cookies.token;渡す
+
+  return { props: { data } };
+}) satisfies GetServerSideProps<{
+  data: {
+    [K: string]: string;
+  };
+}>;


### PR DESCRIPTION
投稿データ内でクッキーの情報からユーザー情報を取得して、バックエンド側(現在はモック)にarticles内のuserデータを送信するように設計しました。API指示書にはuser情報を送るような内容は書かれていなかったので、もしかしたらいらない実装かもです。コメントアウトしましたが、すぐにtoken機能が使えるようなコードも追加しました。(getServerSidePropsでtokenを受け取って、headersとして認証コードを送信できるような仕組み)