### PR TITLE
Colorリンクコンポーネントのクリックイベントの修正

### DIFF
--- a/src/components/ColorLink/ColorLink.tsx
+++ b/src/components/ColorLink/ColorLink.tsx
@@ -4,7 +4,7 @@ import ColorLinkStyle from "@/components/ColorLink/ColorLink.module.css";
 interface Props {
   colorLinkText: string | boolean;
   url: string;
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 }
 
 export default function ColorLink({ colorLinkText, url, onClick }: Props) {

--- a/src/components/lists/Lists.tsx
+++ b/src/components/lists/Lists.tsx
@@ -65,9 +65,9 @@ export default function Lists({ pagedata }: Props) {
   };
 
   return (
-    <ul className={Style.ul} onClick={handleNavigate}>
+    <ul className={Style.ul}>
       {sortedData.map((post) => (
-        <li key={post.articleId}>
+        <li key={post.articleId} onClick={handleNavigate}>
           <RoundFrame>
             <div>
               <p>作成日: {formatDate(post.created_at)}</p>
@@ -76,6 +76,10 @@ export default function Lists({ pagedata }: Props) {
             <ColorLink
               url={`/user/${post.user.userId}`}
               colorLinkText={post.user.name}
+              onClick={(e) => {
+                e.stopPropagation(); // これで親へのイベント伝播を防ぐ
+                router.push(`/user/${post.user.userId}`);
+              }}
             ></ColorLink>
 
             <h3>「{post.title}」</h3>


### PR DESCRIPTION
カラーリンクを押下すると、それを囲うフレームの遷移先にとんでしまうエラーを解消しました
Listコンポーネントに記載されたColorリンクは押下時にユーザー投稿一覧へ遷移するように設定