### PR TITLE
mypage作成＆退会処理

### DIFF
--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -28,13 +28,13 @@ export default function Dialog({
               <Button
                 buttonText={noButtonText}
                 size="S"
-                type="submit"
+                type="button"
                 buttonClick={noButton}
               ></Button>
               <Button
                 buttonText={yesButtonText}
                 size="S"
-                type="submit"
+                type="button"
                 buttonClick={okButton}
               ></Button>
             </div>

--- a/src/components/editOnlyRoundFrame/EditRoundFrame.tsx
+++ b/src/components/editOnlyRoundFrame/EditRoundFrame.tsx
@@ -1,0 +1,40 @@
+import Image from "next/image";
+import RoundFrame from "../roundFrame/RoundFrame";
+import EditRoundFrameStyle from "../editRoundFrame/editRoundFrame.module.css";
+
+interface Props {
+  deleteClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  editClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+
+  children: React.ReactNode;
+}
+export default function EditOnlyRoundFrame({
+  deleteClick,
+  editClick,
+
+  children,
+}: Props) {
+  return (
+    <RoundFrame>
+      <div className={EditRoundFrameStyle.iconLayout}>
+        <div className={EditRoundFrameStyle.icons}>
+          <button
+            onClick={editClick}
+            className={EditRoundFrameStyle.icon}
+            type="button"
+          >
+            <div>
+              <Image
+                src="/common/edit_icon.png"
+                alt="編集アイコン"
+                width={20}
+                height={20}
+              ></Image>
+            </div>
+          </button>
+        </div>
+      </div>
+      {children}
+    </RoundFrame>
+  );
+}

--- a/src/components/editOnlyRoundFrame/editRoundFrame.module.css
+++ b/src/components/editOnlyRoundFrame/editRoundFrame.module.css
@@ -1,0 +1,13 @@
+.icon{
+    background-color: var(--whiteColor);
+    border: 0;
+}
+.icons{
+   display: flex;
+   gap: 15%;
+}
+
+.iconLayout{
+display: flex;
+justify-content: end;
+}

--- a/src/pages/register/index.tsx
+++ b/src/pages/register/index.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import inputStyle from "@/components/input/input.module.css";
 import Button from "@/components/button/Button";
 import registerStyle from "@/styles/Register.module.css";
-import ColorLink from "@/components/ColorLink/ColorLink";
+import ColorLink from "@/components/colorLink/ColorLink";
 import { useRouter } from "next/router";
 
 export default function Register() {


### PR DESCRIPTION
- mypage内でログインcookieを取得し、ログインユーザーの情報を表示する処理
- 退会ボタンを押し、「はい」を選択した際の退会処理（DBから該当のユーザー情報削除）

を実装しました。
退会処理が完了するとトースト表示→2.5秒後にトップページに遷移する挙動になっています。
（同時にログアウトの処理（クッキーの削除）も必要かと思いましたが、JWT?がよくわからなかったので一旦割愛してます）

あと、ダイアログのボタンがサブミットだとデータ削除時にレンダリングでエラーが起きてしまったためsubmitではなくbuttonに変更しています。

![image](https://github.com/user-attachments/assets/5986daa8-723c-44af-a7c3-416c3543b353)
![image](https://github.com/user-attachments/assets/03846c87-81c0-4e07-b96a-bcf69f8b1da3)
