### PR TITLE
ヘッダーのcss編集

### DIFF
--- a/src/components/header/header.module.css
+++ b/src/components/header/header.module.css
@@ -1,6 +1,9 @@
 .header {
   background-color: var(--foreground);
   font-size: 16px;
+  position: fixed;
+  width: 100%;
+  z-index: 100;
 }
 
 .headerIcons {
@@ -26,12 +29,13 @@
 
 @media screen and (min-width: 600px) {
   .header {
-    height: 100%;
     width: 250px;
     background-color: var(--foreground);
     color: var(--background);
-    position: sticky;
-    position: -webkit-sticky;
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100vh;
   }
 
   .headerIcons {
@@ -49,5 +53,9 @@
     list-style: none;
     text-align: left;
     padding-left: 20px;
+  }
+
+  .mobileUl {
+    display: none;
   }
 }

--- a/src/components/header/header.module.css
+++ b/src/components/header/header.module.css
@@ -17,10 +17,13 @@
 .mobileUl {
   display: flex;
   flex-direction: column;
-  justify-self: start;
-  align-items: start;
+  text-align: center;
+  justify-content: space-around;
+  letter-spacing: 5px;
   gap: 1.5rem;
-  padding: 20px;
+  padding: 100px 20px 200px 20px;
+  height: 100vh;
+  font-size: 20px;
 }
 
 .pcUl {

--- a/src/components/layout/layout.module.css
+++ b/src/components/layout/layout.module.css
@@ -25,6 +25,7 @@
 
   .layout {
     display: flex;
+    margin-left: 200px;
   }
 
   .sectionLayout {


### PR DESCRIPTION
## 変更内容
- PCのヘッダーが最下部まで表示されないのを修正
- モバイルのヘッダーを開く際、ヘッダーがボディよりも上に表示されるよう修正
(ハンバーガーメニューを開いた、画面いっぱいに表示)


## 画像
PC
![image](https://github.com/user-attachments/assets/c38b37de-990b-4eb0-ac9b-86a3f2f9a0ea)

モバイル
|ログイン時|未ログイン時|
| --- | --- |
|![image](https://github.com/user-attachments/assets/fadca251-5966-4212-b8a8-e1003b4ae677)|![image](https://github.com/user-attachments/assets/69f7dd53-136a-4ab1-a8fb-6cfd05e2b0e4)|
