### PR TITLE
markdownの改行エラー修正

### DIFF
--- a/src/components/markDown/markDown.module.css
+++ b/src/components/markDown/markDown.module.css
@@ -25,7 +25,7 @@
 }
 
 .html {
-  display: flex;
+  display: block;
   width: 100%;
   padding: 5px;
   border-radius: 3px;
@@ -34,7 +34,6 @@
   word-wrap: break-word; /* 長い単語を折り返す */
   word-break: break-all; /* 必要に応じて単語を途中で分割 */
   overflow: auto; /* スクロールを有効にする */
-
 }
 
 .pcUl {


### PR DESCRIPTION
## 変更箇所
markdownで改行時に横並びになってしまうところを修正しました

## 画像
|変更前|変更後|
| --- | --- |
|![image](https://github.com/user-attachments/assets/7319ec47-8ee1-4d14-b4ec-1b0f573f3228)|![image](https://github.com/user-attachments/assets/d3b43b21-e9f9-4a6e-b63c-4b997ec94448)|