### PR TITLE
投稿詳細編集

### DIFF
--- a/src/components/comment/comment.module.css
+++ b/src/components/comment/comment.module.css
@@ -1,37 +1,42 @@
 .comment_header {
-    font-size: 14px;
+  font-size: 14px;
 }
 
 .comment_name {
-    font-weight: bold;
-    margin-right: 5px;
-    color: black;
+  font-weight: bold;
+  margin-right: 5px;
+  color: black;
 }
 
 .comment_name:hover {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 
 .comment_date {
-    color: #8c8c8c;
+  color: #8c8c8c;
 }
 
 .comment_content {
-    font-size: 14px;
-    margin: 5px 0 15px;
+  font-size: 14px;
+  margin: 5px 0 15px;
+  width: 100%; /* 親要素の幅に合わせる */
+  max-width: 100%; /* 親要素を超えない */
+  box-sizing: border-box; /* パディングやボーダーを含めたサイズ計算 */
+  white-space: pre-wrap; /* 改行を維持しつつテキストを折り返す */
+  overflow-wrap: break-word; /* 長い単語も折り返す */
 }
 
 .comment_input {
-    height: 150px;
-    width: 100%;
-    padding: 15px;
+  height: 150px;
+  width: 100%;
+  padding: 15px;
 }
 
 .button_container {
-    display: flex;
-    justify-content: center;
+  display: flex;
+  justify-content: center;
 }
 
 .button_margin {
-    margin-right: 80px;
+  margin-right: 80px;
 }

--- a/src/pages/post_details/[id].tsx
+++ b/src/pages/post_details/[id].tsx
@@ -115,7 +115,7 @@ export default function PostDetails({ postData, loginUserId, token }: Props) {
     }
   };
 
-  // テキストエリアの onChange ハンドラー（入力値を更新するだけ）
+  // テキストエリアの onChange ハンドラー
   const handleOnChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
 
@@ -123,6 +123,8 @@ export default function PostDetails({ postData, loginUserId, token }: Props) {
 
     if (value.length > 500) {
       setCommentError("コメントは500文字以内で入力してください");
+    } else if (value.length == 0) {
+      setCommentError("コメントを入力してください");
     } else {
       setCommentError("");
     }

--- a/src/pages/post_details/[id].tsx
+++ b/src/pages/post_details/[id].tsx
@@ -115,14 +115,22 @@ export default function PostDetails({ postData, loginUserId, token }: Props) {
     }
   };
 
-  // 新規コメント投稿処理
+  // テキストエリアの onChange ハンドラー（入力値を更新するだけ）
+  const handleOnChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+
+    setNewComment(value);
+
+    if (value.length > 500) {
+      setCommentError("コメントは500文字以内で入力してください");
+    } else {
+      setCommentError("");
+    }
+  };
+
+  // 新規コメント投稿処理（フォーム送信時）
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-
-    if (newComment.length <= 0 || newComment.length > 500) {
-      setCommentError("コメントは1文字以上500文字以内で入力してください");
-      return;
-    }
 
     if (loginUserId == null) {
       router.push("/login");
@@ -273,15 +281,22 @@ export default function PostDetails({ postData, loginUserId, token }: Props) {
         ) : (
           <Form handleSubmit={handleSubmit} noValidate={false}>
             <div>
-              <p className={styles.error_msg}>{commentError}</p>
               <textarea
-                className={styles.post_input}
+                className={styles.textarea}
                 placeholder="ここにコメントを入力してください"
                 value={newComment}
-                onChange={(e) => setNewComment(e.target.value)}
+                onChange={handleOnChange}
               ></textarea>
+              {commentError && (
+                <p className={styles.error_msg}>{commentError}</p>
+              )}
               <div className={styles.button}>
-                <Button type="submit" buttonText="投稿" size="S" />
+                <Button
+                  type="submit"
+                  buttonText="投稿"
+                  size="S"
+                  disabled={!!commentError}
+                />
               </div>
             </div>
           </Form>

--- a/src/styles/post_details.module.css
+++ b/src/styles/post_details.module.css
@@ -25,6 +25,11 @@
 
 .post_content {
   margin: 50px 0;
+  width: 100%; /* 親要素の幅に合わせる */
+  max-width: 100%; /* 親要素を超えない */
+  box-sizing: border-box; /* パディングやボーダーを含めたサイズ計算 */
+  white-space: pre-wrap; /* 改行を維持しつつテキストを折り返す */
+  overflow-wrap: break-word;
 }
 
 .comment_title {
@@ -67,9 +72,21 @@
   color: red;
 }
 
-@media (min-width: 600px) {
+.textarea {
+  width: 100%;
+  min-height: 100px;
+  overflow-y: auto;
+  resize: vertical;
+  border: none;
+}
 
+@media (min-width: 600px) {
   .button {
     text-align: right;
   }
+}
+
+.error_msg {
+  font-size: 14px;
+  color: red;
 }


### PR DESCRIPTION
## 変更内容
- コメント欄が500文字を超えた場合と未入力の場合、投稿ボタンを押下する前にエラー表示＆ボタン非活性化に変更
- コメントの文字が増えるとフレームを超えて表示されていたため修正
【new】
- 新規投稿と投稿編集時、投稿ボタンを押下する前にエラー表示＆ボタン非活性化に変更
## 画像
|500文字超えた場合|未入力の場合|
| --- | --- |
|![image](https://github.com/user-attachments/assets/7029b111-5fe3-4c8b-92e1-a194719a2da1)|![image](https://github.com/user-attachments/assets/be04b681-6be9-4033-83d7-7c29d97b00ce)|

【new】
|未入力時|文字数超過時|
| --- | --- |
|![image](https://github.com/user-attachments/assets/fbfecf43-cc00-47a0-89e1-461f1026a888)|![image](https://github.com/user-attachments/assets/9cf64304-efbc-4bb0-9b7a-0eeffce87505)|
