### PR TITLE
ログアウトするとすぐに反映。トーストのクラス指定による表示の変更

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -2,8 +2,9 @@ import Link from "next/link";
 import { useState } from "react";
 import HeaderStyle from "../header/header.module.css";
 import Image from "next/image";
-import useSWR from "swr";
 import Toast from "../toast/Toast";
+import toastStyle from "../toast/Toast.module.css";
+import useSWR, { mutate } from "swr"; // `mutate` をインポート
 
 export default function Header() {
   const [hamburger, setHamburger] = useState(false);
@@ -32,6 +33,7 @@ export default function Header() {
         setTimeout(() => {
           setToast(""), setView(false);
         }, 2000);
+        mutate("/api/me", null, { revalidate: true });
       }
     } catch {
       setView(true);
@@ -46,7 +48,9 @@ export default function Header() {
   return (
     <div className={HeaderStyle.header}>
       <div className={HeaderStyle.headerContents}>
-        {view && <Toast toastText={toast}></Toast>}
+        {view && (
+          <Toast toastClass={toastStyle.toastArea} toastText={toast}></Toast>
+        )}
         <div className={HeaderStyle.headerIcons} onClick={changeShape}>
           {hamburger ? (
             <div className={HeaderStyle.hamburger}>

--- a/src/components/lists/Lists.tsx
+++ b/src/components/lists/Lists.tsx
@@ -2,7 +2,7 @@ import RoundFrame from "@/components/roundFrame/RoundFrame";
 
 import ColorLink from "@/components/colorLink/ColorLink";
 import Style from "../lists/lists.module.css";
-import { JSX } from "react";
+import { JSX, useState } from "react";
 import { useRouter } from "next/router";
 
 // 日付をスラッシュ形式にフォーマットする関数
@@ -42,7 +42,17 @@ interface Props {
 }
 
 export default function Lists({ pagedata }: Props) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const perPage = 8;
   const router = useRouter();
+
+  const totalPage = Math.ceil((pagedata || []).length / perPage);
+
+  const sliceData = pagedata.slice(
+    currentPage * perPage - perPage,
+    currentPage * perPage
+  );
+
   const splitAndLimitByHeadings = (content: string): JSX.Element[] => {
     // ### ごとに分割して配列化
     const sections = content.split("###");
@@ -55,38 +65,62 @@ export default function Lists({ pagedata }: Props) {
     ));
   };
 
-  const sortedData = [...pagedata].sort(
+  const sortedData = [...sliceData].sort(
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
   );
 
   return (
-    <ul className={Style.ul}>
-      {sortedData.map((post) => (
-        <li
-          key={post.articleId}
-          onClick={(e) => {
-            router.push(`/post_details/${post.articleId}`);
-          }}
-        >
-          <RoundFrame>
-            <div>
-              <p>作成日: {formatDate(post.createdAt)}</p>
-            </div>
-            <span>作成者:</span>
-            <ColorLink
-              url={`/user/${post.user.userId}`}
-              colorLinkText={post.user.name}
-              onClick={(e) => {
-                e.stopPropagation(); // これで親へのイベント伝播を防ぐ
-                router.push(`/user/${post.user.userId}`);
-              }}
-            ></ColorLink>
+    <>
+      <ul className={Style.ul}>
+        {sortedData.map((post) => (
+          <li
+            key={post.articleId}
+            onClick={(e) => {
+              router.push(`/post_details/${post.articleId}`);
+            }}
+          >
+            <RoundFrame>
+              <div>
+                <p>作成日: {formatDate(post.createdAt)}</p>
+              </div>
+              <span>作成者:</span>
+              <ColorLink
+                url={`/user/${post.user.userId}`}
+                colorLinkText={post.user.name}
+                onClick={(e) => {
+                  e.stopPropagation(); // これで親へのイベント伝播を防ぐ
+                  router.push(`/user/${post.user.userId}`);
+                }}
+              ></ColorLink>
 
-            <h3>「{post.title}」</h3>
-            {splitAndLimitByHeadings(post.content)}
-          </RoundFrame>
-        </li>
-      ))}
-    </ul>
+              <h3>「{post.title}」</h3>
+              {splitAndLimitByHeadings(post.content)}
+            </RoundFrame>
+          </li>
+        ))}
+      </ul>
+
+      <div className={Style.pageNation}>
+        <div>
+          <button
+            onClick={() => currentPage > 1 && setCurrentPage(currentPage - 1)}
+          >
+            前へ
+          </button>
+        </div>
+        <p>
+          {currentPage}/{totalPage}
+        </p>
+        <div>
+          <button
+            onClick={() =>
+              currentPage < totalPage && setCurrentPage(currentPage + 1)
+            }
+          >
+            次へ
+          </button>
+        </div>
+      </div>
+    </>
   );
 }

--- a/src/components/lists/lists.module.css
+++ b/src/components/lists/lists.module.css
@@ -4,3 +4,24 @@
     gap: 20px;
     list-style: none;
 }
+
+.pageNation{
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    align-items: center;
+    padding: 1.5rem;
+}
+
+.pageNation button{
+    padding: 0.5rem;
+}
+.pageNation button:hover{
+    color: var(--whiteColor);
+    background-color: var(--foreground)
+
+}
+
+.pageNation p{
+    letter-spacing: 0.5rem;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import Layout from "@/components/layout/Layout";
 import Lists from "@/components/lists/Lists";
+import { useState } from "react";
 import useSWR from "swr";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
@@ -12,6 +13,7 @@ export default function Home() {
 
   if (error) return <div>failed to load</div>;
   if (isLoading) return <div>loading...</div>;
+
   return (
     <>
       <Layout


### PR DESCRIPTION
useSWRのmuteto機能してキャッシュの削除を即座に行うことで、リロードせずにサイドバーの表示切替ができるようになりました。toastの表示方法を変更していなかったので、表示されていなかったのですが、クラスを当てることで表示できるようにしています

ブランチ変えるの忘れてたのですが💦
listコンポーネントにページネーションを当てました。8投稿ずつでページが切り替わって見えるようになっています。


![image](https://github.com/user-attachments/assets/66e22503-be41-4d93-860c-780aba67febc)
![image](https://github.com/user-attachments/assets/b69845ed-f92c-4e20-965a-0c756cc2e36d)
