### PR TITLE
新規登録 - ログイン画面に遷移するように修正

### DIFF
--- a/src/pages/register/confirm.tsx
+++ b/src/pages/register/confirm.tsx
@@ -27,7 +27,7 @@ export default function Confirm() {
     if (data) {
       setUserData(JSON.parse(data));
     }
-  });
+  }, []);
 
   const [toast, setToast] = useState(toastStyle.toastAreaHidden);
 


### PR DESCRIPTION
ページ内で無限ループが起きていたのが原因で画面遷移しなかった可能性があります。
正しい記載方法に修正しました。
