### PR TITLE
投稿詳細画面の時間表示の変更

### DIFF
--- a/src/components/comment/Comment.tsx
+++ b/src/components/comment/Comment.tsx
@@ -8,13 +8,23 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import Toast from "../toast/Toast";
 
 const formatDate = (dateString: string): string => {
-  const date = new Date(dateString);
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}/${month}/${day}`;
+  // "Z"を付与するなどで明示的にUTCとして扱う
+  const date = new Date(
+    dateString.endsWith("Z") ? dateString : dateString + "Z"
+  );
+  const options: Intl.DateTimeFormatOptions = {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  };
+  return date.toLocaleString("ja-JP", options).replace(/,/g, "");
 };
 
 interface User {
@@ -118,12 +128,14 @@ export default function Comment({ comment, loginUserId, token }: CommentProps) {
       }
     );
     showToastFor2Seconds(() => {
-      window.location.reload();
+      router.push(`/${pathname}`);
     });
   };
 
   return (
     <>
+      {showToast && <Toast toastText="削除しました" />}
+
       {/* 削除ダイアログ（コメント用） */}
       {showDeleteCommentDialog && (
         <Dialog

--- a/src/pages/post_details/[id].tsx
+++ b/src/pages/post_details/[id].tsx
@@ -16,11 +16,17 @@ import remarkGfm from "remark-gfm";
 import Link from "next/link";
 
 const formatDate = (dateString: string): string => {
-  const date = new Date(dateString);
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}/${month}/${day}`;
+  // "Z"を付与するなどで明示的にUTCとして扱う
+  const date = new Date(
+    dateString.endsWith("Z") ? dateString : dateString + "Z"
+  );
+  const options: Intl.DateTimeFormatOptions = {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  };
+  return date.toLocaleString("ja-JP", options);
 };
 
 interface User {
@@ -57,6 +63,7 @@ export default function PostDetails({ postData, loginUserId, token }: Props) {
   const postUserId = user.userId;
   const posterName = user.name;
   const postDate = formatDate(createdAt);
+  const updateDate = formatDate(updatedAt);
 
   const [newComment, setNewComment] = useState("");
   const [commentError, setCommentError] = useState("");
@@ -205,7 +212,7 @@ export default function PostDetails({ postData, loginUserId, token }: Props) {
                     作成日 <span>{postDate}</span>
                   </p>
                   <p className={styles.label}>
-                    更新日 <span>{postDate}</span>
+                    更新日 <span>{updateDate}</span>
                   </p>
                 </div>
               </div>
@@ -230,19 +237,13 @@ export default function PostDetails({ postData, loginUserId, token }: Props) {
           <>
             {commentList
               .sort((a, b) => {
-                // updatedAt の昇順で比較
-                const updatedA = new Date(a.updatedAt).getTime();
-                const updatedB = new Date(b.updatedAt).getTime();
-                if (updatedA !== updatedB) {
-                  return updatedA - updatedB;
-                }
-                // updatedAt が同じ場合、createdAt の昇順で比較
+                // createdAt の昇順で比較
                 const createdA = new Date(a.createdAt).getTime();
                 const createdB = new Date(b.createdAt).getTime();
                 if (createdA !== createdB) {
                   return createdA - createdB;
                 }
-                // さらに、両者が同じ場合は commentId の昇順で比較
+                //createdAtが同じ場合は commentId の昇順で比較
                 return a.commentId - b.commentId;
               })
               .map((comment) => (


### PR DESCRIPTION
## 変更内容
- コメント削除時に、トーストが表示されないエラーを解消
- 投稿詳細画面の記事、コメントの日時を日本時間で表示するよう変更
- 投稿詳細画面の記事の更新日が更新されるよう変更

## 画像
|記事の更新日の更新|日付を日本時間で表示|
| --- | --- |
|![image](https://github.com/user-attachments/assets/e095e56b-7b73-4e8c-b92e-75fdc586a7d0)|![image](https://github.com/user-attachments/assets/3494982a-da8f-4752-8c33-29e999ea37f0)|
